### PR TITLE
Fix opening files in terminal and add Kitty support

### DIFF
--- a/src/budgie_desktop_view.vala
+++ b/src/budgie_desktop_view.vala
@@ -29,6 +29,7 @@ public const int ITEM_MARGIN = 10;
 public const string[] SUPPORTED_TERMINALS = {
 	"alacritty",
 	"gnome-terminal",
+	"kitty",
 	"konsole",
 	"mate-terminal",
 	"terminator",


### PR DESCRIPTION
This adds support for Kitty terminal, and fixes opening files in the terminal. If it is deemed that only text files should be able to be opened in a terminal, then that can be added as another commit to this PR, or as a follow-up in the future.

# Summary: 
- Alacritty doesn't support a new tab CLI option, and fails to start if an unknown option is set
- gnome-terminal doesn't support -e, have to use -- instead
- Use the EDITOR env variable to get the default editor, falling back to nano if not set

# Testing
Tested by opening a directory and a text file in the following terminals: Alacritty, gnome-terminal, Kitty, Konsole, and Tilix (Mate-terminal and Terminator don't work on my system currently).

# Linked Issues
#14